### PR TITLE
FR3 - Brewery Can Delete Beer

### DIFF
--- a/BreweryWholesale/BreweryWholesale.Business/Repository/BeerRepository.cs
+++ b/BreweryWholesale/BreweryWholesale.Business/Repository/BeerRepository.cs
@@ -16,10 +16,26 @@ namespace BreweryWholesale.Infrastructure.Repository
         {
             return await _context.Set<Beer>().ToListAsync();
         }
-        
+
+        public async Task<IEnumerable<Beer>> GetBeersByBreweryNameAndBeerNameAsync(int breweryID, string beerName)
+        {
+            return await _context.Set<Beer>().Where(W => W.BreweryID == breweryID && W.Name == beerName).ToListAsync();
+        }
+
+        public async Task<IEnumerable<Beer>> GetBeersByBeerIdAsync(int beerId)
+        {
+            return await _context.Set<Beer>().Where(W => W.BeerID == beerId).ToListAsync();
+        }
+
         public async Task AddBeerAsync(Beer beer)
         {
             _context.Add<Beer>(beer);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteBeerAsync(Beer beer)
+        {
+            _context.Remove<Beer>(beer);
             await _context.SaveChangesAsync();
         }
     }

--- a/BreweryWholesale/BreweryWholesale.Business/Repository/IBeerRepository.cs
+++ b/BreweryWholesale/BreweryWholesale.Business/Repository/IBeerRepository.cs
@@ -5,7 +5,10 @@ namespace BreweryWholesale.Infrastructure.Repository
     public interface IBeerRepository
     {
         Task<IEnumerable<Beer>> GetAllBeersAsync();
+        Task<IEnumerable<Beer>> GetBeersByBreweryNameAndBeerNameAsync(int breweryID, string beerName);
+        Task<IEnumerable<Beer>> GetBeersByBeerIdAsync(int beerId);
         Task AddBeerAsync(Beer beer);
+        Task DeleteBeerAsync(Beer beer);
     }
 
 }

--- a/BreweryWholesale/BreweryWholesale.Business/Services/BeerServices.cs
+++ b/BreweryWholesale/BreweryWholesale.Business/Services/BeerServices.cs
@@ -59,5 +59,36 @@ namespace BreweryWholesale.Infrastructure.Services
             }
         }
 
+        public async Task<IEnumerable<Beer>> GetBeerByBreweryByIdAsync(int beerId)
+        {
+            try
+            {
+                var result = await _beerRepository.GetBeersByBeerIdAsync(beerId);
+                return result;
+            }
+            catch (Exception e)
+            {
+                throw;
+            }
+        }
+
+        public async Task DeleteBeerAsync(int beerId)
+        {
+            try
+            {
+                Beer? existingBeer = GetBeerByBreweryByIdAsync(beerId).Result.FirstOrDefault();
+                if (existingBeer == null)
+                {
+                    throw new CustomExceptions("Beer Does not exist", (int)System.Net.HttpStatusCode.NotFound);
+                }
+
+                await _beerRepository.DeleteBeerAsync(existingBeer);
+            }
+            catch (Exception e)
+            {
+                throw;
+            }
+        }
+
     }
 }

--- a/BreweryWholesale/BreweryWholesale.Domain/Models/Contracts/IBeerService.cs
+++ b/BreweryWholesale/BreweryWholesale.Domain/Models/Contracts/IBeerService.cs
@@ -7,5 +7,7 @@ namespace BreweryWholesale.Domain.Models.Contracts
     {
         Task<IEnumerable<Beer>> GetAllBeersAsync();
         Task AddBeerAsync(Beer_Dto beer_Dto);
+        Task DeleteBeerAsync(int beerId);
+        
     }
 }

--- a/BreweryWholesale/BreweryWholesale/Controllers/BeerController.cs
+++ b/BreweryWholesale/BreweryWholesale/Controllers/BeerController.cs
@@ -2,6 +2,7 @@
 using BreweryWholesale.Domain.Models.DTO;
 using BreweryWholesale.Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 
 namespace BreweryWholesale.Api.Controllers
 {
@@ -43,6 +44,26 @@ namespace BreweryWholesale.Api.Controllers
             catch (CustomExceptions ex)
             {
                 return StatusCode(ex.StatusCode,ex.Message );
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+            }
+        }
+
+
+        [HttpDelete]
+        [Route("DeleteBeerById")]
+        public async Task<IActionResult> DeleteBeerById([FromQuery][Required] int beerId)
+        {
+            try
+            {
+                await _beerService.DeleteBeerAsync(beerId);
+                return Ok();
+            }
+            catch (CustomExceptions ex)
+            {
+                return StatusCode(ex.StatusCode, ex.Message);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Adding Functionality : 
A Brewery can Delete a beer Using Beer Id
Here we used beer Id since we assume that we will be sending the BeerId To UI when Loading all beers for each brewery,
hence on deletion we can send the Beer Id Since it is a unique key, to the back end to delete the record.